### PR TITLE
Follow Speakerdeck new style

### DIFF
--- a/lib/presentations/page/speaker_deck.rb
+++ b/lib/presentations/page/speaker_deck.rb
@@ -8,7 +8,7 @@ module Presentations
       end
 
       def date
-        Time.parse(@document.search("mark")[0].inner_text).to_date
+        Time.parse(@document.search(".deck-meta .text-muted")[0].inner_text).to_date
       end
 
       def image_url


### PR DESCRIPTION
The new style does not have date as `mark` element, so this change updates the query to get a date element.


This patch uses the underlined date element.
<img width="866" alt="screen shot 2018-06-08 at 14 42 26" src="https://user-images.githubusercontent.com/4361134/41140799-6c750df0-6b2a-11e8-8bb8-101c1ee33cf5.png">

I checked that `Time.parse` can parse the date format in local.